### PR TITLE
perf(orders): add indexes and serialize status cascade

### DIFF
--- a/models/order.js
+++ b/models/order.js
@@ -97,6 +97,11 @@ const orderSchema = new mongoose.Schema({
     },
 });
 
+orderSchema.index({ dealer_id: 1, created_at: -1 });
+orderSchema.index({ salesman_id: 1, created_at: -1 });
+orderSchema.index({ status: 1 });
+orderSchema.index({ created_at: -1 });
+
 orderSchema.pre("save", function (next) {
     const now = getISTDate();
     this.updated_at = now;

--- a/models/orderDetails.js
+++ b/models/orderDetails.js
@@ -124,6 +124,11 @@ const orderDetailsSchema = new mongoose.Schema({
     },
 });
 
+orderDetailsSchema.index({ order_number: 1 });
+orderDetailsSchema.index({ product_id: 1 });
+orderDetailsSchema.index({ status: 1 });
+orderDetailsSchema.index({ order_number: 1, status: 1 });
+
 orderDetailsSchema.pre("save", function (next) {
     const istNow = getISTDate();
     if (this.isNew) this.created_at = istNow;

--- a/service/order/orderService.js
+++ b/service/order/orderService.js
@@ -1283,14 +1283,12 @@ const orderService = {
         if (status) {
             const normalizedStatus = normalizeStatus(status);
 
-            // Cascade status to all order details
-            await Promise.all(
-                updatedDetails.map(detail =>
-                    orderService.updateOrderDetailStatus(
-                        detail.order_details_number, { status: normalizedStatus }
-                    )
-                )
-            );
+            // Cascade status to all order details (sequential to avoid races on parent Order.save())
+            for (const detail of updatedDetails) {
+                await orderService.updateOrderDetailStatus(
+                    detail.order_details_number, { status: normalizedStatus }
+                );
+            }
 
             // Re-fetch after cascading update
             updatedDetails = await OrderDetails.find({ order_number: orderNumber });


### PR DESCRIPTION
Add indexes on Order (dealer_id, salesman_id, status, created_at) and OrderDetails (order_number, product_id, status) to support hot query paths in orderService. Replace parallel Promise.all cascade with a sequential loop in updateOrderAndDetails to prevent races on the parent order.save().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Enhanced database query performance for order lookups and filtering.

* **Updates**
  * Improved order status update processing reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/smart-enterprises/inverter-management-api/pull/279?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->