### PR TITLE
fix(orders): gate all stock auto-return sites with ENABLE_STOCK_RETURNS

### DIFF
--- a/service/order/orderService.js
+++ b/service/order/orderService.js
@@ -1267,9 +1267,12 @@ const orderService = {
         reason,
     }) => {
         for (const detail of updatedDetails) {
-            logger.info(`🔄 Returning stock for order detail ${detail._id} → CANCELLED ${JSON.stringify(detail, null, 2)}`);
+            logger.info(`🔄 Cancelling order detail ${detail._id} → CANCELLED ${JSON.stringify(detail, null, 2)}`);
 
-            await returnStockForDetail({ d: detail, employeeId, employeeRole, orderNumber });
+            // Stock auto-return is gated by ENABLE_STOCK_RETURNS env flag.
+            if (ENABLE_STOCK_RETURNS === "true") {
+                await returnStockForDetail({ d: detail, employeeId, employeeRole, orderNumber });
+            }
 
             // Record the cancelled qty + audit trail + recalc pricing so
             // analytics (revenue_cancelled, total_cancelled_qty) stays correct.
@@ -1339,8 +1342,12 @@ const orderService = {
 
         if ([ORDER_STATUSES.CANCELLED, ORDER_STATUSES.REJECTED].includes(normalized)) {
             for (const d of details) {
-                logger.info(`🔄 Returning stock for order detail ${d._id} → ${normalized} ${JSON.stringify(d, null, 2)}`);
-                await returnStockForDetail({ d, employeeId, employeeRole, orderNumber });
+                logger.info(`🔄 ${normalized} order detail ${d._id} ${JSON.stringify(d, null, 2)}`);
+
+                // Stock auto-return is gated by ENABLE_STOCK_RETURNS env flag.
+                if (ENABLE_STOCK_RETURNS === "true") {
+                    await returnStockForDetail({ d, employeeId, employeeRole, orderNumber });
+                }
 
                 // Mirror the qty-cancel bookkeeping so analytics + audit trail
                 // see consistent total_cancelled_qty / cancellation_history /


### PR DESCRIPTION
Previously only updateOrderDetailStatus (single-line cancel) honoured the ENABLE_STOCK_RETURNS env flag. cancelOrderAndReturnStock (whole-order cancel) and updateOrderStatus (order -> CANCELLED/REJECTED) called returnStockForDetail unconditionally, so stock was still being moved even when the flag was meant to disable it.

Now all 3 call sites are gated by the same `ENABLE_STOCK_RETURNS === "true"` check. With the flag unset (current state), stock counters stay where they were on cancellation; cancellation bookkeeping (status flip, audit history, total_cancelled_qty, price recalc) continues to run.

To re-enable later: set ENABLE_STOCK_RETURNS=true in .env.